### PR TITLE
Remove regexp based namespace unpacking

### DIFF
--- a/src/main/NamespacedStorage.ts
+++ b/src/main/NamespacedStorage.ts
@@ -151,7 +151,10 @@ export class NamespacedStorage implements Storage {
    * @since   1.0.0
    */
   public clear(): void {
-    this.keys.forEach(key => this.storage.removeItem(key));
+    this.keys.forEach(key => {
+      const namespacedKey = this.packNamespacedKey(key);
+      this.storage.removeItem(namespacedKey);
+    });
     this.keys = [];
   }
 
@@ -175,7 +178,7 @@ export class NamespacedStorage implements Storage {
    */
   public key(index: number): string | null {
     return index in this.keys
-      ? this.unpackNamespacedKey(this.keys[index])
+      ? this.keys[index]
       : null;
   }
 
@@ -188,7 +191,7 @@ export class NamespacedStorage implements Storage {
   public removeItem(key: string): void {
     const namespacedKey = this.packNamespacedKey(key);
     this.storage.removeItem(namespacedKey);
-    this.keys = this.keys.filter(key => key !== namespacedKey);
+    this.keys = this.keys.filter(currentKey => currentKey !== key);
   }
 
   /**
@@ -201,14 +204,7 @@ export class NamespacedStorage implements Storage {
   public setItem(key: string, value: string): void {
     const namespacedKey = this.packNamespacedKey(key);
     this.storage.setItem(namespacedKey, value);
-    if (!this.keys.includes(namespacedKey)) this.keys.push(namespacedKey);
-  }
-
-  private unpackNamespacedKey(key: string): string {
-    return key.replace(
-      new RegExp(`^${this.namespace}\\${NamespacedStorage.namespaceSeparator}`),
-      '',
-    );
+    if (!this.keys.includes(key)) this.keys.push(key);
   }
 
   private packNamespacedKey(key: string): string {

--- a/src/main/NamespacedStorage.ts
+++ b/src/main/NamespacedStorage.ts
@@ -137,12 +137,17 @@ export class NamespacedStorage implements Storage {
     while (keyIndex--) {
       const key: string | null = storage.key(keyIndex);
       if (!key) continue;
-      if (key.startsWith(`${namespace}.`)) keys.push(key);
+      if (key.startsWith(`${namespace}${NamespacedStorage.namespaceSeparator}`)) keys.push(NamespacedStorage.unpackNamespacedKey(key, namespace));
     }
     return new Proxy(
       new NamespacedStorage(storage, namespace, keys),
       this.proxyHandler,
     );
+  }
+
+  private static unpackNamespacedKey(key: string, namespace: string) {
+    const indexOfFirstLetterWithoutNamespace = `${namespace}${NamespacedStorage.namespaceSeparator}`.length;
+    return key.substring(indexOfFirstLetterWithoutNamespace)
   }
 
   /**


### PR DESCRIPTION
This PR decreases the number of switches between namespaced <---> unnamespaced keys, by keeping the unnamespaced keys inside a NamespacedStorage, instead of the namespaced versions.
With this solution we can get rid of the regexp based namespace unpacking, which also allows as to have keys like `sameName.differentName.sameName`.
It also contains the following changes:
- Make logical dependency into a physical one in `create` function. (Use `NamespacedStorage.namespaceSeparator` instead of `'.'`)
- Add unit test for #create static method.